### PR TITLE
Inexistent gid causes crash

### DIFF
--- a/src/aafm-gui.py
+++ b/src/aafm-gui.py
@@ -293,7 +293,12 @@ class Aafm_GUI:
 	def _get_group(self, filename):
 		st = os.stat(filename)
 		gid = st.st_gid
-		return grp.getgrgid(gid)[0]
+		try:
+			groupname = grp.getgrgid(gid)[0]
+		except KeyError:
+			print 'unknown gid %d for file %s' % (gid, filename)
+			groupname = 'unknown'
+		return groupname
 	
 	def _get_group_windows(self, filename):
 		return ""


### PR DESCRIPTION
Fix for issue #38

Now mapping inexistent gid to the group 'unknown'
