### PR TITLE
Recursive copying does not copy files if they didn't existed

### DIFF
--- a/src/Aafm.py
+++ b/src/Aafm.py
@@ -234,6 +234,8 @@ class Aafm:
 						return
 
 					self.copy_to_device( src_file, device_dst_dir )
+                                else:
+                                        self.copy_to_device( src_file, device_dst_dir )
 
 
 	def device_rename_item(self, device_src_path, device_dst_path):


### PR DESCRIPTION
There was a missing else when copying the contents inside a directory.
