### PR TITLE
Various fixes and improvements

### DIFF
--- a/src/Aafm.py
+++ b/src/Aafm.py
@@ -106,7 +106,7 @@ class Aafm:
 	def is_device_file_a_directory(self, device_file):
 		parent_dir = os.path.dirname(device_file)
 		filename = os.path.basename(device_file)
-		entries = self.device_list_files_parsed(parent_dir)
+		entries = self.device_list_files_parsed(self._path_join_function(parent_dir, ''))
 
 		if not entries.has_key(filename):
 			return False

--- a/src/Aafm.py
+++ b/src/Aafm.py
@@ -29,20 +29,7 @@ class Aafm:
 
 	def execute(self, command):
 		print "EXECUTE=", command
-		process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE).stdout
-
-		lines = []
-
-		while True:
-			line = process.readline()
-			
-			if not line:
-				break
-
-			lines.append(line)
-		
-		return lines
-
+		return subprocess.Popen(command, shell=True, stdout=subprocess.PIPE).stdout.readlines()
 
 	def set_host_cwd(self, cwd):
 		self.host_cwd = cwd

--- a/src/Aafm.py
+++ b/src/Aafm.py
@@ -114,12 +114,8 @@ class Aafm:
 		return entries[filename]['is_directory']
 
 	def device_make_directory(self, directory):
-		pattern = re.compile(r'(\w|_|-)+')
-		base = os.path.basename(directory)
-		if pattern.match(base):
+		if not self.is_device_file_a_directory(directory):
 			self.adb_shell('mkdir', directory)
-		else:
-			print 'invalid directory name', directory
 	
 	
 	def device_delete_item(self, path):

--- a/src/aafm-gui.py
+++ b/src/aafm-gui.py
@@ -165,7 +165,7 @@ class Aafm_GUI:
 		# And we're done!
 		self.window.show_all()
 
-	def refresh_menu_devices(self):
+	def refresh_menu_devices(self, widget=None):
 		self.aafm.refresh_devices()
 		selected = self.aafm.get_device_serial()
 
@@ -179,9 +179,7 @@ class Aafm_GUI:
 		menu = self.menuDevices
 		submenu = gtk.Menu()
 		group = None
-		print 'getting subitems'
 		for serial, name in self.aafm.get_devices():
-			print 'serial:', serial, 'name:', name
 			item = gtk.RadioMenuItem(group, '%s (%s)' % (name, serial))
 			if serial == selected:
 				item.set_active(True)
@@ -190,7 +188,12 @@ class Aafm_GUI:
 			if group is None:
 				group = item
 			submenu.append(item)
+		submenu.append(gtk.SeparatorMenuItem())
+		item = gtk.MenuItem('Refresh device list')
+		item.connect('activate', self.refresh_menu_devices)
+		submenu.append(item)
 		menu.set_submenu(submenu)
+		menu.show_all()
 
 
 

--- a/src/aafm-gui.py
+++ b/src/aafm-gui.py
@@ -599,25 +599,15 @@ class Aafm_GUI:
 
 
 	def copy_from_device_task(self, rows):
-		completed = 0
-		total = len(rows)
-
-		self.update_progress()
-
 		for row in rows:
 			filename = row['filename']
-			is_directory = row['is_directory']
 
 			full_device_path = self.aafm.device_path_join(self.device_cwd, filename)
 			full_host_path = self.host_cwd
-			
-			self.aafm.copy_to_host(full_device_path, full_host_path)
-			completed = completed + 1
-			self.refresh_host_files()
-			self.update_progress(completed * 1.0 / total)
 
-			yield True
+			self.add_to_queue(self.QUEUE_ACTION_COPY_FROM_DEVICE, full_device_path, full_host_path)
 
+		self.process_queue()
 		yield False
 
 	def on_device_rename_item_callback(self, widget):

--- a/src/aafm-gui.py
+++ b/src/aafm-gui.py
@@ -67,6 +67,13 @@ class Aafm_GUI:
 		showHidden = builder.get_object('showHidden')
 		showHidden.connect('toggled', self.on_toggle_hidden)
 
+		# Refresh view
+		refreshView = builder.get_object('refreshView')
+		refreshView.connect('activate', self.refresh_all)
+
+		itemQuit = builder.get_object('itemQuit')
+		itemQuit.connect('activate', gtk.main_quit)
+
 		# Host and device TreeViews
 		
 		# HOST
@@ -145,8 +152,7 @@ class Aafm_GUI:
 		self.host_cwd = os.getcwd()
 		self.device_cwd = '/mnt/sdcard/'
 
-		self.refresh_host_files()
-		self.refresh_device_files()
+		self.refresh_all()
 
 		# Make both panels equal in size (at least initially)
 		panelsPaned = builder.get_object('panelsPaned')
@@ -184,6 +190,9 @@ class Aafm_GUI:
 			self.aafm.set_device_cwd(self.device_cwd)
 			self.refresh_device_files()
 
+	def refresh_all(self, widget=None):
+		self.refresh_host_files()
+		self.refresh_device_files()
 	
 	def refresh_host_files(self):
 		self.host_treeViewFile.load_data(self.dir_scan_host(self.host_cwd))
@@ -379,8 +388,7 @@ class Aafm_GUI:
 	def on_toggle_hidden(self, widget):
 		self.showHidden = widget.get_active()
 
-		self.refresh_host_files()
-		self.refresh_device_files()
+		self.refresh_all()
 
 	def on_host_tree_view_contextual_menu(self, widget, event):
 		if event.button == 3: # Right click

--- a/src/aafm-gui.py
+++ b/src/aafm-gui.py
@@ -676,6 +676,10 @@ class Aafm_GUI:
 			self.progress_bar.set_text("Done")
 			self.progress_bar.set_fraction(0)
 
+		# Make sure the GUI has some cycles for processing events
+		while gtk.events_pending():
+			gtk.main_iteration(False)
+
 
 	def on_host_drag_data_get(self, widget, context, selection, target_type, time):
 		data = '\n'.join(['file://' + urllib.quote(os.path.join(self.host_cwd, item['filename'])) for item in self.get_host_selected_files()])

--- a/src/aafm-gui.py
+++ b/src/aafm-gui.py
@@ -795,7 +795,7 @@ class Aafm_GUI:
 		self.update_progress()
 
 		while len(self.queue) > 0:
-			item = self.queue.pop()
+			item = self.queue.pop(0)
 			action, src, dst = item
 
 			if action == self.QUEUE_ACTION_COPY_TO_DEVICE:

--- a/src/aafm-gui.py
+++ b/src/aafm-gui.py
@@ -150,9 +150,8 @@ class Aafm_GUI:
 
 		# Make both panels equal in size (at least initially)
 		panelsPaned = builder.get_object('panelsPaned')
-		panelW, panelH = panelsPaned.size_request()
-		halfW = panelW / 2
-		panelsPaned.set_position(halfW)
+		self.window.show_all()
+		panelsPaned.set_position(panelsPaned.get_allocation().width / 2)
 
 		# And we're done!
 		self.window.show_all()

--- a/src/aafm-gui.py
+++ b/src/aafm-gui.py
@@ -166,15 +166,18 @@ class Aafm_GUI:
 		self.window.show_all()
 
 	def refresh_menu_devices(self, widget=None):
+		before = self.aafm.get_device_serial()
 		self.aafm.refresh_devices()
 		selected = self.aafm.get_device_serial()
+		if before != selected:
+			self.aafm.set_device_cwd('/mnt/sdcard/')
+			self.refresh_device_files()
 
 		def on_menu_item_toggled(item, serial):
 			if item.get_active():
-				print 'selecting item:', serial
 				self.aafm.set_device_serial(serial)
 				self.aafm.set_device_cwd('/mnt/sdcard/')
-				self.refresh_all()
+				self.refresh_device_files()
 
 		menu = self.menuDevices
 		submenu = gtk.Menu()
@@ -187,6 +190,10 @@ class Aafm_GUI:
 			item.connect('toggled', on_menu_item_toggled, serial)
 			if group is None:
 				group = item
+			submenu.append(item)
+		if group is None:
+			item = gtk.MenuItem('No devices found')
+			item.set_sensitive(False)
 			submenu.append(item)
 		submenu.append(gtk.SeparatorMenuItem())
 		item = gtk.MenuItem('Refresh device list')

--- a/src/data/glade/interface.xml
+++ b/src/data/glade/interface.xml
@@ -7,11 +7,77 @@
     <property name="width_request">640</property>
     <property name="height_request">480</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="border_width">10</property>
-    <signal name="destroy" handler="on_window_destroy"/>
+    <signal name="destroy" handler="on_window_destroy" swapped="no"/>
     <child>
       <object class="GtkVBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkMenuBar" id="menubar1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkMenuItem" id="menuitem1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_File</property>
+                <property name="use_underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu" id="menu1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkImageMenuItem" id="itemQuit">
+                        <property name="label">gtk-quit</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="use_stock">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="menuitem3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_View</property>
+                <property name="use_underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu" id="menu4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="showHidden">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Show hidden files and folders</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="refreshView">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Refresh</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkHPaned" id="panelsPaned">
             <property name="visible">True</property>
@@ -19,11 +85,13 @@
             <child>
               <object class="GtkFrame" id="frameHost">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label_xalign">0</property>
                 <property name="shadow_type">none</property>
                 <child>
                   <object class="GtkAlignment" id="alignment1">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <placeholder/>
                     </child>
@@ -32,6 +100,7 @@
                 <child type="label">
                   <object class="GtkLabel" id="frameHostLabel">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Host</property>
                     <property name="use_markup">True</property>
                   </object>
@@ -45,11 +114,13 @@
             <child>
               <object class="GtkFrame" id="frameDevice">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label_xalign">0</property>
                 <property name="shadow_type">none</property>
                 <child>
                   <object class="GtkAlignment" id="alignment2">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <placeholder/>
                     </child>
@@ -58,6 +129,7 @@
                 <child type="label">
                   <object class="GtkLabel" id="frameDeviceLabel">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Device</property>
                     <property name="use_markup">True</property>
                   </object>
@@ -70,33 +142,20 @@
             </child>
           </object>
           <packing>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="showHidden">
-            <property name="label" translatable="yes">Show _hidden files and folders</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">False</property>
-            <property name="use_action_appearance">False</property>
-            <property name="draw_indicator">True</property>
-            <property name="use_underline">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="padding">4</property>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkProgressBar" id="progressBar">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="text" translatable="yes">Ready</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="padding">0</property>
+            <property name="fill">True</property>
             <property name="position">2</property>
           </packing>
         </child>

--- a/src/data/glade/interface.xml
+++ b/src/data/glade/interface.xml
@@ -42,6 +42,14 @@
               </object>
             </child>
             <child>
+              <object class="GtkMenuItem" id="menuDevices">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Devices</property>
+                <property name="use_underline">True</property>
+              </object>
+            </child>
+            <child>
               <object class="GtkMenuItem" id="menuitem3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>


### PR DESCRIPTION
Sorry for just having a single big pull request, if you want to have some commits singled out as separate pull request, I can do that (just tell me which ones you want).

This basically gives you:
- Update the UI at least after each file (process events)
- Better running of processes (and parsing their output), no need to use the shell or quoting
- Make the task queue FIFO (was LIFO)
- Only create directory on the device when needed
- Recursive copying and deletion should do proper progress reporting
- Fix panels paned width calculation (was wrong for me on Fedora 20)
- Don't re-implemented "copy to computer" logic for the context menu
- Use a Gtk main menu instead of a single checkbox (for hidden files)
- Support for having multiple devices connected (+GUI for selecting)
- Show free disk space of current directory on device
- Refresh device list menu item, and "no devices found" handling

I didn't take too much care about making sure this works on Windows as well (device path handling), that could be done, but haven't gotten around to doing it yet (just scratching an itch here).

Ideally I'd like to see all commands being run in a separate thread, so that the UI never blocks. And while there's no progress indication for long-running adb push/pull commands (e.g. pushing or pulling a 50 MiB file), it might be nice to parse adb's output, remember the "best" transfer rate for the device in the session and then based on file size and expected transfer rate, come up with a way to display "in-file" progress. This is not perfect, but might make the experience better (well, faking fine-grained progress information) than just updating the progress bar after every file.
